### PR TITLE
Support non-vpn usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,4 +7,6 @@ It's a static site using handlebars js and materialize css.
 
 To run it locally, you'll need to create a file called config.js with this line in it:
 
-`const imageHost = <your image host url>`
+`const mediaImgIxToken = salt for images from the fastly image vcl`
+
+Alternatively just set `salt=<override value for image salt urls>`

--- a/public/index.html
+++ b/public/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>


### PR DESCRIPTION
## What does this change?
This change removes the need for config in this project by allowing the user to set `salt=` query string parameter that will override the salt used for images rather than fetching from config. It also removes the 'fastly host' parameter - instead simply hard coding the base path for the fastly image service we use on theguardian.com