### PR TITLE
Maintenance and cosmetic fixes

### DIFF
--- a/_site/assets/favicon.svg
+++ b/_site/assets/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-16 -16 32 32">
+    <text x="-14" y="6" font-size="24">🏞️</text>
+    <text x="-3" y="12" font-size="18">🔍</text>
+</svg>

--- a/_site/components/Column.svelte
+++ b/_site/components/Column.svelte
@@ -15,7 +15,7 @@
   const ratio = (src) => {
     const [, , , , crop] = src.pathname.split("/");
     if (!crop) return 1;
-    const [width, height] = crop.split("_").slice(2);
+    const [width, height] = crop.split("_").slice(2).map(Number);
     return height / width;
   };
 

--- a/_site/components/Images.island.svelte
+++ b/_site/components/Images.island.svelte
@@ -4,7 +4,8 @@
   const IS_BROWSER = typeof document !== "undefined";
 
   /** @type {string} */
-  let input = "img/media/d9ede9177cd8a01c7a7e87da54fb15e0615adf20/0_1597_6000_3599/master/6000.jpg";
+  let input =
+    "img/media/d9ede9177cd8a01c7a7e87da54fb15e0615adf20/0_1597_6000_3599/master/6000.jpg";
 
   let width = (IS_BROWSER ? Number() : undefined) || 320;
 
@@ -44,18 +45,17 @@
         new URLSearchParams({
           width: String(width),
           configs: JSON.stringify(configs),
-          paths: input.replaceAll("\n", ","),
+          paths: input.replaceAll("\n", "+"),
         })
     );
     configs = configs;
   };
 
   const parseValues = () => {
-    if (!IS_BROWSER) return;
     input =
       new URLSearchParams(window.location.search)
         .get("paths")
-        ?.replaceAll(",", "\n") ?? input;
+        ?.replaceAll("+", "\n") ?? input;
     width = Number(
       new URLSearchParams(window.location.search).get("width") ?? width
     );
@@ -65,7 +65,7 @@
     );
   };
 
-  parseValues();
+  IS_BROWSER && parseValues();
 </script>
 
 <label>

--- a/_site/components/Images.island.svelte
+++ b/_site/components/Images.island.svelte
@@ -4,26 +4,16 @@
   const IS_BROWSER = typeof document !== "undefined";
 
   /** @type {string} */
-  let input =
-    (IS_BROWSER
-      ? new URLSearchParams(window.location.search)
-          .get("paths")
-          ?.replaceAll(",", "\n")
-      : undefined) ?? "";
+  let input = "img/media/d9ede9177cd8a01c7a7e87da54fb15e0615adf20/0_1597_6000_3599/master/6000.jpg";
 
-  let width =
-    (IS_BROWSER
-      ? Number(new URLSearchParams(window.location.search).get("width"))
-      : undefined) ?? 320;
+  let width = (IS_BROWSER ? Number() : undefined) || 320;
 
   $: urls = input
     .split("\n")
     .filter(Boolean)
     .map((path) => new URL(path, "https://fastly-io-code.guim.co.uk"));
 
-  let configs = (IS_BROWSER
-    ? JSON.parse(new URLSearchParams(window.location.search).get("configs"))
-    : undefined) ?? [
+  let configs = [
     {
       dpr: 1,
       quality: 85,
@@ -59,6 +49,23 @@
     );
     configs = configs;
   };
+
+  const parseValues = () => {
+    if (!IS_BROWSER) return;
+    input =
+      new URLSearchParams(window.location.search)
+        .get("paths")
+        ?.replaceAll(",", "\n") ?? input;
+    width = Number(
+      new URLSearchParams(window.location.search).get("width") ?? width
+    );
+    configs = JSON.parse(
+      new URLSearchParams(window.location.search).get("configs") ??
+        JSON.stringify(configs)
+    );
+  };
+
+  parseValues();
 </script>
 
 <label>

--- a/_site/components/Images.island.svelte
+++ b/_site/components/Images.island.svelte
@@ -11,12 +11,15 @@
           ?.replaceAll(",", "\n")
       : undefined) ?? "";
 
+  let width =
+    (IS_BROWSER
+      ? Number(new URLSearchParams(window.location.search).get("width"))
+      : undefined) ?? 320;
+
   $: urls = input
     .split("\n")
     .filter(Boolean)
     .map((path) => new URL(path, "https://fastly-io-code.guim.co.uk"));
-
-  let width = 320;
 
   let configs = (IS_BROWSER
     ? JSON.parse(new URLSearchParams(window.location.search).get("configs"))
@@ -49,6 +52,7 @@
       "",
       "?" +
         new URLSearchParams({
+          width: String(width),
           configs: JSON.stringify(configs),
           paths: input.replaceAll("\n", ","),
         })
@@ -71,7 +75,17 @@
 
 <label>
   Width
-  <input type="number" max="1300" step="1" bind:value={width} />
+  <input
+    type="number"
+    max="1300"
+    step="10"
+    bind:value={width}
+    on:input={() => {
+      updateQueryParam();
+      // reload everything!
+      urls = urls;
+    }}
+  />
 </label>
 
 <hr />

--- a/_site/routes/index.svelte
+++ b/_site/routes/index.svelte
@@ -8,6 +8,7 @@
     name="description"
     content="Deploy small websites built with Svelte with islands of interactivity."
   />
+  <link rel="icon" href="/assets/favicon.svg" />
 </svelte:head>
 
 <body>
@@ -22,7 +23,8 @@
 <style>
   :global(:root) {
     color-scheme: dark;
-    font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+    font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo,
+      Consolas, "DejaVu Sans Mono", monospace;
   }
   body {
     background-color: #112;

--- a/_site/routes/index.svelte
+++ b/_site/routes/index.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-  <title>Mononykus – Deno + Svelte</title>
+  <title>Image Comparison Tool</title>
   <meta
     name="description"
     content="Deploy small websites built with Svelte with islands of interactivity."
@@ -13,8 +13,14 @@
 
 <body>
   <main>
-    <h1>Image Comparison tool</h1>
+    <h1>Image Comparison Tool</h1>
     <h2>Compare various image qualities and formats</h2>
+
+    <p>
+      Built from <a href="https://github.com/guardian/image-comparison-tool"
+        >guardian/image-comparison-tool</a
+      >
+    </p>
 
     <Images />
   </main>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add an SVG favicon
- Reload images when the width is changed
- Adjust some logic to make thing easier to maintain, including parsing of config in URL
- Handle URL separator

## How to test

It’s [already deployed](http://image-comparison-tool.s3-website-eu-west-1.amazonaws.com/)!

## How can we measure success?

Maintenance

## Have we considered potential risks?

None forseen.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [X] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
