### PR TITLE
Fix explicit lossy format `webply`

### DIFF
--- a/_site/components/Column.svelte
+++ b/_site/components/Column.svelte
@@ -1,5 +1,5 @@
 <script>
-  /** @type {{ format: 'avif' | 'webp' | 'png8' | 'pjpg', dpr: 1 | 2, quality: number }} */
+  /** @type {Config} */
   export let config;
 
   /** @type {number} */
@@ -28,6 +28,13 @@
       };
       reader.readAsDataURL(blob);
     });
+
+  const formats = /** @type {const} @satisfies {Config.format[]}*/ ([
+    "avif",
+    "webply",
+    "png8",
+    "pjpg",
+  ]);
 
   const format_size = (size) => `${(size / 1000).toFixed(1)} kB`;
 
@@ -96,7 +103,7 @@
     Format
 
     <select bind:value={config.format} on:change={handleChange}>
-      {#each ["avif", "webp", "png8", "pjpg"] as image_format}
+      {#each formats as image_format}
         <option value={image_format} selected={image_format === config.format}>
           {image_format}
         </option>

--- a/_site/components/Images.island.svelte
+++ b/_site/components/Images.island.svelte
@@ -14,6 +14,7 @@
     .filter(Boolean)
     .map((path) => new URL(path, "https://fastly-io-code.guim.co.uk"));
 
+  /** @type {Config} */
   let configs = [
     {
       dpr: 1,
@@ -28,7 +29,7 @@
     {
       dpr: 2,
       quality: 25,
-      format: "webp",
+      format: "webply",
     },
     {
       dpr: 2,

--- a/_site/components/types.js
+++ b/_site/components/types.js
@@ -1,0 +1,6 @@
+/**
+ * @typedef {object} Config
+ * @property {'avif' | 'webply' | 'png8' | 'pjpg'} format
+ * @property {1 | 2} dpr
+ * @property {number} quality
+ */


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Without this specific format, images with transparency are not compressed for WebP.

## How to test

Run locally.

## How can we measure success?

`webp` will no longer be an acceptable format for our image service.

## Have we considered potential risks?

N/A

## Images

They look more compressed…

## Accessibility

N/A