### PR TITLE
Add support for Jpeg XL

### DIFF
--- a/_site/components/Column.svelte
+++ b/_site/components/Column.svelte
@@ -31,6 +31,7 @@
 
   const formats = /** @type {const} @satisfies {Config.format[]}*/ ([
     "avif",
+    "jxl",
     "webply",
     "png8",
     "pjpg",
@@ -53,6 +54,7 @@
         // TODO: get headers from actual browsing session!
         Accept: [
           "image/avif",
+          "image/jxl",
           "image/webp",
           "image/png",
           "image/svg+xml",

--- a/_site/components/Images.island.svelte
+++ b/_site/components/Images.island.svelte
@@ -36,6 +36,11 @@
       quality: 55,
       format: "avif",
     },
+    {
+      dpr: 2,
+      quality: 55,
+      format: "jxl",
+    },
   ];
 
   const updateQueryParam = () => {

--- a/_site/components/types.js
+++ b/_site/components/types.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {object} Config
- * @property {'avif' | 'webply' | 'png8' | 'pjpg'} format
+ * @property {'avif' | 'jxl' | 'webply' | 'png8' | 'pjpg'} format
  * @property {1 | 2} dpr
  * @property {number} quality
  */


### PR DESCRIPTION
## What does this change?

Add support for `Jpeg XL`. Once merged, I will deploy and make the change, in [`fastly-image-service`](https://github.com/guardian/fastly-image-service) to make it work so we could figure the right quality parameter to enable `Jpeg XL`
