### PR TITLE
Use pjxl rather than jxl to have support for progressive JPEG XL

### DIFF
--- a/_site/components/Column.svelte
+++ b/_site/components/Column.svelte
@@ -31,7 +31,7 @@
 
   const formats = /** @type {const} @satisfies {Config.format[]}*/ ([
     "avif",
-    "jxl",
+    "pjxl",
     "webply",
     "png8",
     "pjpg",

--- a/_site/components/Images.island.svelte
+++ b/_site/components/Images.island.svelte
@@ -39,7 +39,7 @@
     {
       dpr: 2,
       quality: 55,
-      format: "jxl",
+      format: "pjxl",
     },
   ];
 

--- a/_site/components/types.js
+++ b/_site/components/types.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {object} Config
- * @property {'avif' | 'jxl' | 'webply' | 'png8' | 'pjpg'} format
+ * @property {'avif' | 'pjxl' | 'webply' | 'png8' | 'pjpg'} format
  * @property {1 | 2} dpr
  * @property {number} quality
  */


### PR DESCRIPTION
Use the [right format](https://www.fastly.com/documentation/reference/io/format/) to support progressive images